### PR TITLE
Bump bundler to 2.5.17

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,4 +27,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.16
+   2.5.17


### PR DESCRIPTION
Testing Github Actions with Bundler 2.5.17 and git cache.